### PR TITLE
Tune boid parameters

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1,11 +1,12 @@
-export function setupGUI(boids) {
+export function setupGUI(boids, attractor) {
     const maxSpeedInput = document.getElementById('max-speed');
     const alignmentInput = document.getElementById('alignment-strength');
     const cohesionInput = document.getElementById('cohesion-strength');
     const separationInput = document.getElementById('separation-strength');
     const perceptionInput = document.getElementById('perception-radius');
+    const attractorInput = document.getElementById('attractor-strength');
   
-    if (!maxSpeedInput || !alignmentInput || !cohesionInput || !separationInput || !perceptionInput) {
+    if (!maxSpeedInput || !alignmentInput || !cohesionInput || !separationInput || !perceptionInput || !attractorInput) {
       console.warn("GUI-Elemente nicht gefunden – GUI wird nicht aktiviert.");
       return;
     }
@@ -15,7 +16,8 @@ export function setupGUI(boids) {
       const alignment = parseFloat(alignmentInput.value);
       const cohesion = parseFloat(cohesionInput.value);
       const separation = parseFloat(separationInput.value);
-      const perception = parseFloat(perceptionInput.value);
+        const perception = parseFloat(perceptionInput.value);
+        const attract = parseFloat(attractorInput.value);
   
       for (const boid of boids) {
         boid.maxSpeed = maxSpeed;
@@ -24,6 +26,9 @@ export function setupGUI(boids) {
         boid.separationStrength = separation;
         boid.perceptionRadius = perception;
       }
+        if (attractor) {
+          attractor.strength = attract;
+        }
     }
   
     maxSpeedInput.addEventListener('input', updateParameters);
@@ -31,6 +36,7 @@ export function setupGUI(boids) {
     cohesionInput.addEventListener('input', updateParameters);
     separationInput.addEventListener('input', updateParameters);
     perceptionInput.addEventListener('input', updateParameters);
+    attractorInput.addEventListener('input', updateParameters);
   
     updateParameters(); // Direkt initial setzen
   }

--- a/index.html
+++ b/index.html
@@ -16,32 +16,32 @@
     <br>
     <label>
         Attraktor-Stärke:
-        <input type="range" id="attractor-strength" value="0.7" min="0" max="2" step="0.1">
+        <input type="range" id="attractor-strength" value="0.3" min="0" max="1" step="0.05">
     </label>
     <br>
     <label>
         Maximale Geschwindigkeit:
-        <input type="range" id="max-speed" value="1.4" min="0.1" max="3" step="0.1">
+        <input type="range" id="max-speed" value="1" min="0.5" max="2" step="0.1">
     </label>
     <br>
     <label>
         Ausrichtungs-Stärke:
-        <input type="range" id="alignment-strength" value="0.4" min="0" max="1" step="0.01">
+        <input type="range" id="alignment-strength" value="0.2" min="0" max="0.5" step="0.01">
     </label>
     <br>
     <label>
         Kohäsions-Stärke:
-        <input type="range" id="cohesion-strength" value="0.003" min="0" max="0.1" step="0.001">
+        <input type="range" id="cohesion-strength" value="0.01" min="0" max="0.05" step="0.001">
     </label>
     <br>
     <label>
         Trennungs-Stärke:
-        <input type="range" id="separation-strength" value="0.08" min="0" max="0.2" step="0.01">
+        <input type="range" id="separation-strength" value="0.1" min="0" max="0.3" step="0.01">
     </label>
     <br>
     <label>
         Wahrnehmungsradius:
-        <input type="range" id="perception-radius" value="50" min="10" max="100" step="1">
+        <input type="range" id="perception-radius" value="60" min="20" max="80" step="1">
     </label>
   </div>
 


### PR DESCRIPTION
## Summary
- adjust default slider ranges for more realistic flocking behavior
- dampen boid velocity and reduce attractor pull
- expose attractor strength in GUI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f76d3e8308331bfa72c4885d8d212