### PR TITLE
Adjust boid depth limits and improve layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,10 +96,12 @@ class Boid {
         this.velocity.multiplyScalar(0.98);
         this.velocity.clampLength(0.5, this.maxSpeed);
         this.position.add(this.velocity);
-        ['x','y','z'].forEach(axis => {
+        ['x','y'].forEach(axis => {
             if (this.position[axis] > 200) this.position[axis] = -200;
             else if (this.position[axis] < -200) this.position[axis] = 200;
         });
+        if (this.position.z > 200) this.position.z = -500;
+        else if (this.position.z < -500) this.position.z = 200;
         attractor.influence(this);
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,2 +1,19 @@
-body { margin: 0; padding: 0; }
-canvas { display: block; margin: 0; padding: 0;}
+html, body {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+canvas {
+    display: block;
+    margin: 0;
+    padding: 0;
+}
+#boid-config {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.8);
+    font-family: sans-serif;
+    padding: 5px;
+}


### PR DESCRIPTION
## Summary
- clamp boids on the Z axis to prevent immediate warp
- keep the canvas fixed to viewport size
- overlay configuration panel on top of the canvas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880b9a140388331af4dbd58a4f3798d