### PR TITLE
Implement dynamic cloud background

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,12 +1,58 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.1/build/three.module.js';
 
 export function setupBackground(scene) {
-  const loader = new THREE.TextureLoader();
-  loader.load('clouds.jpg', texture => {
-    const backgroundMesh = new THREE.Mesh(
-      new THREE.SphereGeometry(1000, 32, 32),
-      new THREE.MeshBasicMaterial({ map: texture, side: THREE.BackSide })
-    );
-    scene.add(backgroundMesh);
+  const geometry = new THREE.PlaneGeometry(2000, 1000);
+  const uniforms = { time: { value: 0 } };
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    side: THREE.DoubleSide,
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      varying vec2 vUv;
+      uniform float time;
+
+      float rand(vec2 co){
+        return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+      }
+
+      float noise(vec2 p){
+        vec2 i = floor(p);
+        vec2 f = fract(p);
+
+        float a = rand(i);
+        float b = rand(i + vec2(1.0,0.0));
+        float c = rand(i + vec2(0.0,1.0));
+        float d = rand(i + vec2(1.0,1.0));
+
+        vec2 u = f*f*(3.0-2.0*f);
+
+        return mix(a, b, u.x) +
+               (c - a)*u.y*(1.0-u.x) +
+               (d - b)*u.x*u.y;
+      }
+
+      void main() {
+        float n = noise(vUv*4.0 + vec2(time*0.05));
+        float n2 = noise(vUv*8.0 - vec2(time*0.03));
+        float value = smoothstep(0.3,0.7,mix(n,n2,0.5));
+        gl_FragColor = vec4(vec3(value),1.0);
+      }
+    `
   });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.z = -500;
+  scene.add(mesh);
+
+  return {
+    mesh,
+    update(time) {
+      uniforms.time.value = time;
+    }
+  };
 }

--- a/boid.js
+++ b/boid.js
@@ -2,7 +2,7 @@ import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.1/build/three.m
 
 export function createBoids(boids, scene) {
   const geometry = new THREE.SphereGeometry(1.5, 6, 6);
-  const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
+  const material = new THREE.MeshBasicMaterial({ color: 0xdddddd });
   const range = 300;
 
   class Boid {

--- a/index.html
+++ b/index.html
@@ -67,11 +67,6 @@
     </div>
 
   <script type="module">
-    import './background.js';
-    import './3d-setup.js';
-    import './boid.js';
-    import './attractor.js';
-    import './gui.js';
     import './script.js';
   </script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.1/build/three.module.js';
 import { setupGUI } from './gui.js';
+import { setupBackground } from './background.js';
 
 // Szene, Kamera und Renderer erstellen
 const scene = new THREE.Scene();
@@ -11,13 +12,7 @@ const nearColor = new THREE.Color(0x000000);
 const farColor = backgroundColor;
 
 // Hintergrund
-const loader = new THREE.TextureLoader();
-const backgroundTexture = loader.load('clouds.jpg');
-const backgroundMaterial = new THREE.MeshBasicMaterial({ map: backgroundTexture });
-const backgroundGeometry = new THREE.PlaneGeometry(window.innerWidth, window.innerHeight);
-const backgroundMesh = new THREE.Mesh(backgroundGeometry, backgroundMaterial);
-backgroundMesh.position.z = -500;
-scene.add(backgroundMesh);
+const { update: updateBackground } = setupBackground(scene);
 
 renderer.setSize(window.innerWidth, window.innerHeight);
 window.addEventListener('resize', onWindowResize);
@@ -45,12 +40,6 @@ class Attractor {
     }
 }
 const attractor = new Attractor(new THREE.Vector3(0, 0, 0), 0.3);
-const attractorMesh = new THREE.Mesh(
-    new THREE.SphereGeometry(1),
-    new THREE.MeshBasicMaterial()
-);
-attractorMesh.position.copy(attractor.position);
-scene.add(attractorMesh);
 
 // Boids
 class Boid {
@@ -361,6 +350,7 @@ const maxDistance = 500;
 
 function animate() {
     requestAnimationFrame(animate);
+    updateBackground(performance.now() * 0.001);
     boids.forEach((boid, i) => {
         boid.update(boids);
         vertices.set([boid.position.x, boid.position.y, boid.position.z], i * 3);


### PR DESCRIPTION
## Summary
- tint boid meshes light gray instead of white
- load animated background from custom shader
- remove unused sphere display for attractor
- streamline imports in `index.html`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880c000ddd48331bb8cd90646a2604b