### PR TITLE
Add cloud controls

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,7 +8,13 @@ export function setupBackground(scene) {
   const geometry = new THREE.PlaneGeometry(2000, 1000);
   const uniforms = {
     time: { value: 0 },
-    cloudTex: { value: cloudTex }
+    cloudTex: { value: cloudTex },
+    scale1: { value: 4.0 },
+    scale2: { value: 8.0 },
+    noiseMix: { value: 0.5 },
+    lowThreshold: { value: 0.3 },
+    highThreshold: { value: 0.7 },
+    mixStrength: { value: 0.4 }
   };
   const material = new THREE.ShaderMaterial({
     uniforms,
@@ -24,6 +30,12 @@ export function setupBackground(scene) {
       varying vec2 vUv;
       uniform float time;
       uniform sampler2D cloudTex;
+      uniform float scale1;
+      uniform float scale2;
+      uniform float noiseMix;
+      uniform float lowThreshold;
+      uniform float highThreshold;
+      uniform float mixStrength;
 
       float rand(vec2 co){
         return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
@@ -48,10 +60,10 @@ export function setupBackground(scene) {
       void main() {
         vec2 uv = vUv;
         vec4 base = texture2D(cloudTex, uv);
-        float n = noise(uv*4.0 + vec2(time*0.05));
-        float n2 = noise(uv*8.0 - vec2(time*0.03));
-        float value = smoothstep(0.3,0.7,mix(n,n2,0.5));
-        vec3 color = mix(base.rgb, vec3(value), 0.4);
+        float n = noise(uv*scale1 + vec2(time*0.05));
+        float n2 = noise(uv*scale2 - vec2(time*0.03));
+        float value = smoothstep(lowThreshold, highThreshold, mix(n, n2, noiseMix));
+        vec3 color = mix(base.rgb, vec3(value), mixStrength);
         gl_FragColor = vec4(color, 1.0);
       }
     `
@@ -64,6 +76,14 @@ export function setupBackground(scene) {
     mesh,
     update(time) {
       uniforms.time.value = time;
+    },
+    setParams(params) {
+      if (params.scale1 !== undefined) uniforms.scale1.value = params.scale1;
+      if (params.scale2 !== undefined) uniforms.scale2.value = params.scale2;
+      if (params.noiseMix !== undefined) uniforms.noiseMix.value = params.noiseMix;
+      if (params.lowThreshold !== undefined) uniforms.lowThreshold.value = params.lowThreshold;
+      if (params.highThreshold !== undefined) uniforms.highThreshold.value = params.highThreshold;
+      if (params.mixStrength !== undefined) uniforms.mixStrength.value = params.mixStrength;
     }
   };
 }

--- a/index.html
+++ b/index.html
@@ -51,6 +51,36 @@
           <span id="perception-radius-value">60</span>
       </label>
     <br>
+      <label>
+          Cloud Scale 1:
+          <input type="range" id="cloud-scale1" value="4" min="1" max="10" step="0.1">
+          <span id="cloud-scale1-value">4</span>
+      </label>
+    <br>
+      <label>
+          Cloud Scale 2:
+          <input type="range" id="cloud-scale2" value="8" min="1" max="20" step="0.1">
+          <span id="cloud-scale2-value">8</span>
+      </label>
+    <br>
+      <label>
+          Cloud Mix:
+          <input type="range" id="cloud-mix" value="0.5" min="0" max="1" step="0.05">
+          <span id="cloud-mix-value">0.5</span>
+      </label>
+    <br>
+      <label>
+          Low Threshold:
+          <input type="range" id="cloud-low-threshold" value="0.3" min="0" max="1" step="0.01">
+          <span id="cloud-low-threshold-value">0.3</span>
+      </label>
+    <br>
+      <label>
+          High Threshold:
+          <input type="range" id="cloud-high-threshold" value="0.7" min="0" max="1" step="0.01">
+          <span id="cloud-high-threshold-value">0.7</span>
+      </label>
+    <br>
     <label>
         Linien zu Nachbarn anzeigen:
         <input type="checkbox" id="show-lines">

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ const nearColor = new THREE.Color(0x000000);
 const farColor = backgroundColor;
 
 // Hintergrund
-const { update: updateBackground } = setupBackground(scene);
+const { update: updateBackground, setParams: setCloudParams } = setupBackground(scene);
 
 renderer.setSize(window.innerWidth, window.innerHeight);
 window.addEventListener('resize', onWindowResize);
@@ -131,6 +131,11 @@ const alignmentInput = document.getElementById('alignment-strength');
 const cohesionInput = document.getElementById('cohesion-strength');
 const separationInput = document.getElementById('separation-strength');
 const perceptionInput = document.getElementById('perception-radius');
+const scale1Input = document.getElementById('cloud-scale1');
+const scale2Input = document.getElementById('cloud-scale2');
+const noiseMixInput = document.getElementById('cloud-mix');
+const lowThInput = document.getElementById('cloud-low-threshold');
+const highThInput = document.getElementById('cloud-high-threshold');
 
 const numBoidsValue = document.getElementById('num-boids-value');
 const attractorStrengthValue = document.getElementById('attractor-strength-value');
@@ -139,6 +144,11 @@ const alignmentValue = document.getElementById('alignment-strength-value');
 const cohesionValue = document.getElementById('cohesion-strength-value');
 const separationValue = document.getElementById('separation-strength-value');
 const perceptionValue = document.getElementById('perception-radius-value');
+const scale1Value = document.getElementById('cloud-scale1-value');
+const scale2Value = document.getElementById('cloud-scale2-value');
+const noiseMixValue = document.getElementById('cloud-mix-value');
+const lowThValue = document.getElementById('cloud-low-threshold-value');
+const highThValue = document.getElementById('cloud-high-threshold-value');
 
 function updateValueDisplays() {
     if (numBoidsValue) numBoidsValue.textContent = numBoidsInput.value;
@@ -148,9 +158,23 @@ function updateValueDisplays() {
     if (cohesionValue) cohesionValue.textContent = cohesionInput.value;
     if (separationValue) separationValue.textContent = separationInput.value;
     if (perceptionValue) perceptionValue.textContent = perceptionInput.value;
+    if (scale1Value) scale1Value.textContent = scale1Input.value;
+    if (scale2Value) scale2Value.textContent = scale2Input.value;
+    if (noiseMixValue) noiseMixValue.textContent = noiseMixInput.value;
+    if (lowThValue) lowThValue.textContent = lowThInput.value;
+    if (highThValue) highThValue.textContent = highThInput.value;
 }
 
 updateValueDisplays();
+if (setCloudParams) {
+    setCloudParams({
+        scale1: parseFloat(scale1Input.value),
+        scale2: parseFloat(scale2Input.value),
+        noiseMix: parseFloat(noiseMixInput.value),
+        lowThreshold: parseFloat(lowThInput.value),
+        highThreshold: parseFloat(highThInput.value)
+    });
+}
 
 if (numBoidsInput) {
     numBoidsInput.addEventListener('change', () => {
@@ -196,6 +220,24 @@ if (showCoordsInput) {
     }
 });
 
+[scale1Input, scale2Input, noiseMixInput, lowThInput, highThInput].forEach(inp => {
+    if (inp) {
+        inp.addEventListener('input', () => {
+            updateValueDisplays();
+            setCloudParams({
+                scale1: parseFloat(scale1Input.value),
+                scale2: parseFloat(scale2Input.value),
+                noiseMix: parseFloat(noiseMixInput.value),
+                lowThreshold: parseFloat(lowThInput.value),
+                highThreshold: parseFloat(highThInput.value)
+            });
+        });
+        inp.addEventListener('change', () => {
+            updateValueDisplays();
+        });
+    }
+});
+
 const resetButton = document.getElementById('reset-canvas');
 if (resetButton) {
     resetButton.addEventListener('click', () => {
@@ -233,6 +275,11 @@ if (saveButton) {
             cohesionStrength: cohesionInput.value,
             separationStrength: separationInput.value,
             perceptionRadius: perceptionInput.value,
+            cloudScale1: scale1Input.value,
+            cloudScale2: scale2Input.value,
+            cloudMix: noiseMixInput.value,
+            cloudLowThreshold: lowThInput.value,
+            cloudHighThreshold: highThInput.value,
             showLines: showLinesInput.checked,
             showCoords: showCoordsInput.checked
         };
@@ -253,6 +300,11 @@ if (loadButton) {
         if (settings.cohesionStrength !== undefined) cohesionInput.value = settings.cohesionStrength;
         if (settings.separationStrength !== undefined) separationInput.value = settings.separationStrength;
         if (settings.perceptionRadius !== undefined) perceptionInput.value = settings.perceptionRadius;
+        if (settings.cloudScale1 !== undefined) scale1Input.value = settings.cloudScale1;
+        if (settings.cloudScale2 !== undefined) scale2Input.value = settings.cloudScale2;
+        if (settings.cloudMix !== undefined) noiseMixInput.value = settings.cloudMix;
+        if (settings.cloudLowThreshold !== undefined) lowThInput.value = settings.cloudLowThreshold;
+        if (settings.cloudHighThreshold !== undefined) highThInput.value = settings.cloudHighThreshold;
         if (settings.showLines !== undefined) {
             showLinesInput.checked = settings.showLines;
             showLines = showLinesInput.checked;
@@ -263,6 +315,15 @@ if (loadButton) {
             showCoords = showCoordsInput.checked;
         }
         updateValueDisplays();
+        if (setCloudParams) {
+            setCloudParams({
+                scale1: parseFloat(scale1Input.value),
+                scale2: parseFloat(scale2Input.value),
+                noiseMix: parseFloat(noiseMixInput.value),
+                lowThreshold: parseFloat(lowThInput.value),
+                highThreshold: parseFloat(highThInput.value)
+            });
+        }
         const num = parseInt(numBoidsInput.value, 10);
         if (!isNaN(num) && num >= 0) {
             updateBoidCount(num);


### PR DESCRIPTION
## Summary
- add shader uniforms for clouds
- update shader to use uniforms
- expose cloud controls through HTML
- sync GUI with new cloud settings
- persist cloud settings to localStorage

## Testing
- `node --check script.js`
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_6880d7e157a883318552cabb8af6ee28