### PR TITLE
Fix script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,6 @@
 
     <button id="show-controls" style="display:none;">Steuerung einblenden</button>
 
-  <script type="module">
-    import './script.js';
-  </script>
+  <script type="module" src="./script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `script.js` via the `src` attribute so the main logic runs again

## Testing
- `node --check script.js` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed35160c8331ba128a127be8f16a