### PR TITLE
Add adaptive FPS handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,10 +101,11 @@
           <input type="color" id="background-color" value="#222222">
       </label>
       <br>
-      <button id="reset-canvas">Canvas zurücksetzen</button>
-      <button id="save-settings">Einstellungen speichern</button>
-      <button id="load-settings">Einstellungen laden</button>
-    </div>
+        <button id="reset-canvas">Canvas zurücksetzen</button>
+        <button id="save-settings">Einstellungen speichern</button>
+        <button id="load-settings">Einstellungen laden</button>
+        <div id="fps">FPS: <span id="fps-display">0</span></div>
+      </div>
 
   <script type="module" src="./script.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -17,3 +17,7 @@ canvas {
     font-family: sans-serif;
     padding: 5px;
 }
+
+#fps {
+    margin-top: 5px;
+}


### PR DESCRIPTION
## Summary
- show current FPS in the control panel
- measure frame times and compute average FPS
- drop boid count and disable line rendering at low FPS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688134554a688331b5c82d433aad4381