### PR TITLE
Implement blur sliders and deeper z-range

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,8 @@ export function setupBackground(scene) {
     noiseMix: { value: 0.5 },
     lowThreshold: { value: 0.3 },
     highThreshold: { value: 0.7 },
-    mixStrength: { value: 0.4 }
+    mixStrength: { value: 0.4 },
+    blurAmount: { value: 0.0 }
   };
   const material = new THREE.ShaderMaterial({
     uniforms,
@@ -36,6 +37,7 @@ export function setupBackground(scene) {
       uniform float lowThreshold;
       uniform float highThreshold;
       uniform float mixStrength;
+      uniform float blurAmount;
 
       float rand(vec2 co){
         return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
@@ -59,7 +61,12 @@ export function setupBackground(scene) {
 
       void main() {
         vec2 uv = vUv;
-        vec4 base = texture2D(cloudTex, uv);
+        vec4 base = vec4(0.0);
+        base += texture2D(cloudTex, uv) * 0.2;
+        base += texture2D(cloudTex, uv + vec2(blurAmount, 0.0)) * 0.2;
+        base += texture2D(cloudTex, uv - vec2(blurAmount, 0.0)) * 0.2;
+        base += texture2D(cloudTex, uv + vec2(0.0, blurAmount)) * 0.2;
+        base += texture2D(cloudTex, uv - vec2(0.0, blurAmount)) * 0.2;
         float n = noise(uv*scale1 + vec2(time*0.05));
         float n2 = noise(uv*scale2 - vec2(time*0.03));
         float value = smoothstep(lowThreshold, highThreshold, mix(n, n2, noiseMix));
@@ -69,7 +76,7 @@ export function setupBackground(scene) {
     `
   });
   const mesh = new THREE.Mesh(geometry, material);
-  mesh.position.z = -500;
+  mesh.position.z = -1500;
   scene.add(mesh);
 
   return {
@@ -84,6 +91,7 @@ export function setupBackground(scene) {
       if (params.lowThreshold !== undefined) uniforms.lowThreshold.value = params.lowThreshold;
       if (params.highThreshold !== undefined) uniforms.highThreshold.value = params.highThreshold;
       if (params.mixStrength !== undefined) uniforms.mixStrength.value = params.mixStrength;
+      if (params.blurAmount !== undefined) uniforms.blurAmount.value = params.blurAmount;
     }
   };
 }

--- a/index.html
+++ b/index.html
@@ -101,6 +101,18 @@
           <input type="color" id="background-color" value="#222222">
       </label>
       <br>
+      <label>
+          Vordergrund-Blur:
+          <input type="range" id="foreground-blur" value="0" min="0" max="10" step="0.5">
+          <span id="foreground-blur-value">0</span>
+      </label>
+      <br>
+      <label>
+          Hintergrund-Blur:
+          <input type="range" id="background-blur" value="0" min="0" max="10" step="0.5">
+          <span id="background-blur-value">0</span>
+      </label>
+      <br>
         <button id="reset-canvas">Canvas zurücksetzen</button>
         <button id="save-settings">Einstellungen speichern</button>
         <button id="load-settings">Einstellungen laden</button>

--- a/script.js
+++ b/script.js
@@ -89,8 +89,8 @@ class Boid {
             if (this.position[axis] > 200) this.position[axis] = -200;
             else if (this.position[axis] < -200) this.position[axis] = 200;
         });
-        if (this.position.z > 200) this.position.z = -500;
-        else if (this.position.z < -500) this.position.z = 200;
+        if (this.position.z > 400) this.position.z = -1200;
+        else if (this.position.z < -1200) this.position.z = 400;
         attractor.influence(this);
     }
 }
@@ -163,6 +163,8 @@ const lowThInput = document.getElementById('cloud-low-threshold');
 const highThInput = document.getElementById('cloud-high-threshold');
 const fgColorInput = document.getElementById('foreground-color');
 const bgColorInput = document.getElementById('background-color');
+const fgBlurInput = document.getElementById('foreground-blur');
+const bgBlurInput = document.getElementById('background-blur');
 
 const numBoidsValue = document.getElementById('num-boids-value');
 const attractorStrengthValue = document.getElementById('attractor-strength-value');
@@ -176,6 +178,8 @@ const scale2Value = document.getElementById('cloud-scale2-value');
 const noiseMixValue = document.getElementById('cloud-mix-value');
 const lowThValue = document.getElementById('cloud-low-threshold-value');
 const highThValue = document.getElementById('cloud-high-threshold-value');
+const fgBlurValue = document.getElementById('foreground-blur-value');
+const bgBlurValue = document.getElementById('background-blur-value');
 // We don't display color values, but inputs exist for user adjustments
 
 function updateValueDisplays() {
@@ -191,6 +195,8 @@ function updateValueDisplays() {
     if (noiseMixValue) noiseMixValue.textContent = noiseMixInput.value;
     if (lowThValue) lowThValue.textContent = lowThInput.value;
     if (highThValue) highThValue.textContent = highThInput.value;
+    if (fgBlurValue) fgBlurValue.textContent = fgBlurInput.value;
+    if (bgBlurValue) bgBlurValue.textContent = bgBlurInput.value;
 }
 
 updateValueDisplays();
@@ -200,7 +206,8 @@ if (setCloudParams) {
         scale2: parseFloat(scale2Input.value),
         noiseMix: parseFloat(noiseMixInput.value),
         lowThreshold: parseFloat(lowThInput.value),
-        highThreshold: parseFloat(highThInput.value)
+        highThreshold: parseFloat(highThInput.value),
+        blurAmount: parseFloat(bgBlurInput.value)
     });
 }
 
@@ -257,6 +264,22 @@ if (bgColorInput) {
     });
 }
 
+if (fgBlurInput) {
+    boidMaterial.size = 4 + parseFloat(fgBlurInput.value);
+    fgBlurInput.addEventListener('input', () => {
+        boidMaterial.size = 4 + parseFloat(fgBlurInput.value);
+        updateValueDisplays();
+    });
+}
+
+if (bgBlurInput) {
+    if (setCloudParams) setCloudParams({ blurAmount: parseFloat(bgBlurInput.value) });
+    bgBlurInput.addEventListener('input', () => {
+        if (setCloudParams) setCloudParams({ blurAmount: parseFloat(bgBlurInput.value) });
+        updateValueDisplays();
+    });
+}
+
 [maxSpeedInput, alignmentInput, cohesionInput, separationInput, perceptionInput].forEach(inp => {
     if (inp) {
         inp.addEventListener('input', updateValueDisplays);
@@ -273,7 +296,8 @@ if (bgColorInput) {
                 scale2: parseFloat(scale2Input.value),
                 noiseMix: parseFloat(noiseMixInput.value),
                 lowThreshold: parseFloat(lowThInput.value),
-                highThreshold: parseFloat(highThInput.value)
+                highThreshold: parseFloat(highThInput.value),
+                blurAmount: parseFloat(bgBlurInput.value)
             });
         });
         inp.addEventListener('change', () => {
@@ -324,6 +348,8 @@ if (saveButton) {
             cloudMix: noiseMixInput.value,
             cloudLowThreshold: lowThInput.value,
             cloudHighThreshold: highThInput.value,
+            foregroundBlur: fgBlurInput.value,
+            backgroundBlur: bgBlurInput.value,
             showLines: showLinesInput.checked,
             showCoords: showCoordsInput.checked
         };
@@ -349,6 +375,8 @@ if (loadButton) {
         if (settings.cloudMix !== undefined) noiseMixInput.value = settings.cloudMix;
         if (settings.cloudLowThreshold !== undefined) lowThInput.value = settings.cloudLowThreshold;
         if (settings.cloudHighThreshold !== undefined) highThInput.value = settings.cloudHighThreshold;
+        if (settings.foregroundBlur !== undefined) fgBlurInput.value = settings.foregroundBlur;
+        if (settings.backgroundBlur !== undefined) bgBlurInput.value = settings.backgroundBlur;
         if (settings.showLines !== undefined) {
             showLinesInput.checked = settings.showLines;
             showLines = showLinesInput.checked;
@@ -365,7 +393,8 @@ if (loadButton) {
                 scale2: parseFloat(scale2Input.value),
                 noiseMix: parseFloat(noiseMixInput.value),
                 lowThreshold: parseFloat(lowThInput.value),
-                highThreshold: parseFloat(highThInput.value)
+                highThreshold: parseFloat(highThInput.value),
+                blurAmount: parseFloat(bgBlurInput.value)
             });
         }
         const num = parseInt(numBoidsInput.value, 10);
@@ -466,7 +495,7 @@ function adjustSettings(fps) {
 }
 
 const minDistance = 0;
-const maxDistance = 500;
+const maxDistance = 1200;
 
 function animate() {
     requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- add foreground and background blur sliders in the UI
- update script to handle new blur controls and save/load settings
- support blur amount in background shader
- extend boid z-range and distance-based coloring

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688135e1cb0083319f080c0e5bf3cf06