### PR TITLE
Improve overlay layout and heading blend

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,15 +114,17 @@
         <div id="fps">FPS: <span id="fps-display">0</span></div>
       </div>
       <div class="overlay">
-  <h1>Der exquisite Zerfall der Bedeutung im gläsernen Zeitalter</h1>
+        <div class="overlay-content">
+          <h1>Der exquisite Zerfall der Bedeutung im gläsernen Zeitalter</h1>
 
-  <p>
-    Während sich die Worte aneinanderreihen wie schimmernde Glasscherben,
-    bleibt doch das Fundament überraschend klar: Eine Schrift für jene,
-    die zwischen Übertreibung und Präzision leben. Literata erhebt das Banale zur Kunst,
-    Recursive bringt es zurück auf den Boden.
-  </p>
-  </div>
+          <p>
+            Während sich die Worte aneinanderreihen wie schimmernde Glasscherben,
+            bleibt doch das Fundament überraschend klar: Eine Schrift für jene,
+            die zwischen Übertreibung und Präzision leben. Literata erhebt das Banale zur Kunst,
+            Recursive bringt es zurück auf den Boden.
+          </p>
+        </div>
+      </div>
   <script type="module" src="./script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,7 @@ html, body {
     margin: 0;
     padding: 0;
     overflow: hidden;
+    height: 100%;
 }
 body {
     font-family: 'Recursive', sans-serif;
@@ -36,6 +37,10 @@ canvas {
   align-items: center;
   justify-content: center;
 }
+.overlay-content {
+  max-width: 70vw;
+  text-align: center;
+}
 #fps {
     margin-top: 5px;
 }
@@ -44,10 +49,7 @@ h1 {
   font-size: clamp(4rem, 10vw, 8rem);
   font-weight: 700;
   text-align: center;
-  color: transparent;
-  background: white; /* nur Platzhalter – wird vom Canvas ersetzt */
-  background-clip: text;
-  -webkit-background-clip: text;
-  mix-blend-mode: lighten; /* oder screen, overlay, difference */
+  color: #ffffff;
+  mix-blend-mode: screen;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
- wrap overlay text in a container limited to 70% of viewport width
- blend heading with background using CSS `mix-blend-mode: screen`
- ensure page takes up full browser height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68814455ccdc8331ac71f2da15aca18f