### PR TITLE
Adjust heading blend

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -49,10 +49,7 @@ h1 {
   font-size: clamp(4rem, 10vw, 8rem);
   font-weight: 700;
   text-align: center;
-  color: transparent;
-  background: white; /* Placeholder - canvas shows through */
-  background-clip: text;
-  -webkit-background-clip: text;
-  mix-blend-mode: screen;
+  color: #ffffff;
+  mix-blend-mode: overlay;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
- tweak CSS blend mode so the heading text blends with the background

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6881481ceb6c83319112d1fd7975b431