### PR TITLE
Improve overlay layering and transparent title text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@ canvas {
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 10;
+    z-index: 20;
     background: rgba(255, 255, 255, 0.8);
     font-family: sans-serif;
     padding: 5px;
@@ -49,7 +49,11 @@ h1 {
   font-size: clamp(4rem, 10vw, 8rem);
   font-weight: 700;
   text-align: center;
-  color: #ffffff;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 2px white;
+  -webkit-background-clip: text;
+  background-clip: text;
   mix-blend-mode: overlay;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
- let the Boid control panel sit above the text overlay
- make the title text transparent so the canvas shows through while blending with the background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881497362048331b5f0679deb997999